### PR TITLE
Fix local package detection for imports without dots

### DIFF
--- a/src/main/kotlin/eu/oakroot/GoImportTidy.kt
+++ b/src/main/kotlin/eu/oakroot/GoImportTidy.kt
@@ -149,12 +149,13 @@ open class GoImportTidy : AnAction() {
 
     private fun group(s: String, locals: List<String>): Int {
         val path: String = importPath(s)
-        if (!s.contains(".")) {
-            return STD_LIB
+
+        if (path != "" && locals.any { local -> path.contains(local, true) }) {
+            return LOCAL_LIB
         }
 
-        return if (path != "" && locals.any { local -> path.contains(local, true)}) {
-            LOCAL_LIB
+        return if (!s.contains(".")) {
+            STD_LIB
         } else EXTERNAL_LIB
     }
 


### PR DESCRIPTION
### Problem

Local imports like app/... or internal/... were misclassified as standard library packages if they lacked a dot, despite being listed as local modules in the plugin settings.

### Solution

Updated the `group` function to check for local prefixes first.
Now, if the path matches a configured local prefix, it's correctly recognized as a local import, even if it doesn't contain a dot.

### Example

locals = ["app"]

```go
import (
	"app/api/core"
	"app/common/models"
	"app/pkg/dmp"
	"net/http"
	"time"

	"github.com/golang-jwt/jwt/v5"
	"github.com/labstack/echo/v4"
	"golang.org/x/crypto/bcrypt"
)
```
incorrectly grouped as stdlib
